### PR TITLE
address #5 by expanding catch clause behavior

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@master
         with:
-          cli: '1.12.3.1577'
+          cli: '1.12.4.1618'
           bb: 'latest'
       - name: Cache All The Things
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@master
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d
         with:
           cli: '1.12.4.1618'
           bb: 'latest'

--- a/.github/workflows/test-and-snapshot.yml
+++ b/.github/workflows/test-and-snapshot.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@master
         with:
-          cli: '1.12.3.1577'
+          cli: '1.12.4.1618'
           bb: 'latest'
       - name: Cache All The Things
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -49,10 +49,10 @@ jobs:
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@master
         with:
-          cli: '1.12.3.1577'
+          cli: '1.12.4.1618'
           bb: 'latest'
       - name: Cache All The Things
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/test-and-snapshot.yml
+++ b/.github/workflows/test-and-snapshot.yml
@@ -15,7 +15,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@master
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d
         with:
           cli: '1.12.4.1618'
           bb: 'latest'
@@ -47,7 +47,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@master
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d
         with:
           cli: '1.12.4.1618'
           bb: 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@master
         with:
-          cli: '1.12.3.1577'
+          cli: '1.12.4.1618'
           bb: 'latest'
       - name: Cache All The Things
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@master
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d
         with:
           cli: '1.12.4.1618'
           bb: 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '17', '21', '25' ]
+        java: [ '17', '21', '25' ]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /target
 pom.xml
 pom.xml.asc
+outdated.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 * v0.13.next in progress
   * address [clj-commons/slingshot#8](https://github.com/clj-commons/slingshot/issues/8) by removing outdated status note.
+  * address [clj-commons/slingshot#5](https://github.com/clj-commons/slingshot/issues/5) by attempting to catch the wrapper (exception) type if no catch clause matches the wrapped object type.
   * address [clj-commons/slingshot#4](https://github.com/clj-commons/slingshot/issues/4) by merging stacktrace changes from [a20748f](https://github.com/clj-commons/slingshot/commit/a20748fd2d6d4a9020d296a3798e82f136e2bfe2) by [@scgilardi](https://github.com/scgilardi).
   * address [clj-commons/slingshot#3](https://github.com/clj-commons/slingshot/issues/3) by merging `and` optimizations from original PR [#55](https://github.com/scgilardi/slingshot/pull/55) by [@jbouwman](https://github.com/jbouwman).
   * address [scgilardo/slingshot#53](https://github.com/scgilardi/slingshot/issues/53) by adding examples of `else` and `finally`.
+  * update dev/test/build deps
 
 * v0.13.0 -- 2025-09-20
   - add clj-kondo config export

--- a/README.md
+++ b/README.md
@@ -129,6 +129,41 @@ caught {:value 5} {:object {:value 5}, :message important message, :cause nil,
   :throwable #error {...}}
 ```
 
+The above example shows that if you `catch Object`, you can catch non-Throwable
+data (as well as wrapped exceptions) and access the full throw context.
+
+You can also catch based on the wrapper:
+
+```clojure
+user=> (defn foo [x]
+  #_=>   (throw (ex-info "important message" {:value x})))
+  #_=>
+  #_=> (defn -main []
+  #_=>   (try+
+  #_=>     (foo 5)
+  #_=>     (catch Exception e
+  #_=>       (println "caught" e &throw-context))))
+#'user/foo
+#'user/-main
+user=> (-main)
+caught #error {
+ :cause important message
+ :data {:value 5}
+ :via
+ [{:type clojure.lang.ExceptionInfo
+   :message important message
+   :data {:value 5}
+   :at [...]}]
+ :trace
+ [[...]]}
+ {:object {:value 5}, :message important message, :cause nil,
+  :stack-trace #object[[Ljava.lang.StackTraceElement...],
+  :wrapper #error {
+   :cause important message
+   ...},
+  :throwable #error {...}}
+```
+
   Between being thrown and caught, a wrapper may be further wrapped by
   other Exceptions (e.g., instances of `RuntimeException` or
   `java.util.concurrent.ExecutionException`). `try+` sees through all

--- a/bb.edn
+++ b/bb.edn
@@ -16,7 +16,7 @@
               jdk      (or base-jdk
                            ;; sean's local default:
                            "jdk25")]
-          (doseq [v (if all? ["1.8" "1.9" "1.10" "1.11" "1.12"] versions)]
+          (doseq [v (if all? ["1.8" "1.9" "1.10" "1.11" "1.12" "1.13"] versions)]
             (println "\nTesting Clojure" v)
             (shell "clojure"
                    (str "-M"

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
 
  :aliases
  {;; for help: clojure -T:deps:build help/doc
-  :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.11"}
+  :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.12"}
                  slipset/deps-deploy {:mvn/version "0.2.2"}}
           :ns-default build}
 
@@ -12,7 +12,7 @@
   :1.9  {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
   :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
-  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.3"}}}
+  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.4"}}}
 
   ;; running tests/checks of various kinds:
   :test {:extra-paths ["test"]

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
   :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
   :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.4"}}}
-  :1.13 {:override-deps {org.clojure/clojure {:mvn/version "1.13.0-alpha2"}}}
+  :1.13 {:override-deps {org.clojure/clojure {:mvn/version "1.13.0-alpha6"}}}
 
   ;; running tests/checks of various kinds:
   :test {:extra-paths ["test"]

--- a/deps.edn
+++ b/deps.edn
@@ -13,6 +13,7 @@
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
   :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
   :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.4"}}}
+  :1.13 {:override-deps {org.clojure/clojure {:mvn/version "1.13.0-alpha2"}}}
 
   ;; running tests/checks of various kinds:
   :test {:extra-paths ["test"]

--- a/src/clj_commons/slingshot/support.clj
+++ b/src/clj_commons/slingshot/support.clj
@@ -153,28 +153,33 @@
                 `(~selector ~'%))]
            `(let [~'% (:object ~'&throw-context)]
               ~(or (key-values) (selector-form) (predicate)))))
-       (cond-expression [binding-form expressions]
-         `(let [~binding-form (:object ~'&throw-context)]
+       (cond-expression [k binding-form expressions]
+         `(let [~binding-form (~k ~'&throw-context)]
             ~@expressions))
        (transform [[_ selector binding-form & expressions]]
          (if-let [class-selector (class-selector? selector)]
            [`(instance? ~class-selector (:object ~'&throw-context))
-            (cond-expression (with-meta binding-form {:tag selector}) expressions)]
-           [(cond-test selector) (cond-expression binding-form expressions)]))]
+            (cond-expression :object (with-meta binding-form {:tag selector}) expressions)]
+           [(cond-test selector) (cond-expression :object binding-form expressions)]))
+       (transform-wrapper [[_ selector binding-form & expressions]]
+         (when-let [class-selector (class-selector? selector)]
+           [`(instance? ~class-selector (:wrapper ~'&throw-context))
+            (cond-expression :wrapper (with-meta binding-form {:tag selector}) expressions)]))]
     (list
      `(catch Throwable ~'&throw-context
         (reset! ~threw?-sym true)
         (let [~'&throw-context (-> ~'&throw-context get-context *catch-hook*)]
           (cond
-           (contains? ~'&throw-context :catch-hook-return)
-           (:catch-hook-return ~'&throw-context)
-           (contains? ~'&throw-context :catch-hook-throw)
-           (~throw-sym (:catch-hook-throw ~'&throw-context))
-           (contains? ~'&throw-context :catch-hook-rethrow)
-           (~throw-sym)
-           ~@(mapcat transform catch-clauses)
-           :else
-           (~throw-sym)))))))
+            (contains? ~'&throw-context :catch-hook-return)
+            (:catch-hook-return ~'&throw-context)
+            (contains? ~'&throw-context :catch-hook-throw)
+            (~throw-sym (:catch-hook-throw ~'&throw-context))
+            (contains? ~'&throw-context :catch-hook-rethrow)
+            (~throw-sym)
+            ~@(mapcat transform catch-clauses)
+            ~@(mapcat transform-wrapper catch-clauses)
+            :else
+            (~throw-sym)))))))
 
 (defn gen-finally
   "Returns either nil or a list containing a finally clause for a try

--- a/test/clj_commons/slingshot_test.clj
+++ b/test/clj_commons/slingshot_test.clj
@@ -518,3 +518,50 @@
         (is (= result23 [exp msg]))
         (is (= result24 [exp fmt-msg]))
         (is (= result25 [exp fmt2-msg]))))))
+
+(deftest test-catch-exception
+  (testing "throw+ Exception"
+    (let [caught (atom false)]
+      (try+
+       (throw+ (Exception. "test-exception"))
+       (catch Exception e
+         (reset! caught true)
+         (is (= "test-exception" (.getMessage e)))))
+      (is @caught "exception was not caught?"))
+    (let [caught (atom false)]
+      (try+
+       (throw+ (Exception. "test-exception"))
+       (catch Object e
+         (reset! caught true)
+         (is (= "test-exception" (.getMessage e)))))
+      (is @caught "exception was not caught?")))
+  (testing "throw Exception"
+    (let [caught (atom false)]
+      (try+
+       (throw (Exception. "test-exception"))
+       (catch Exception e
+         (reset! caught true)
+         (is (= "test-exception" (.getMessage e)))))
+      (is @caught "exception was not caught?"))
+    (let [caught (atom false)]
+      (try+
+       (throw (Exception. "test-exception"))
+       (catch Object e
+         (reset! caught true)
+         (is (= "test-exception" (.getMessage e)))))
+      (is @caught "exception was not caught?")))
+  (testing "throw data"
+    (let [caught (atom false)]
+      (try+
+       (throw+ {:msg "test-exception"})
+       (catch Exception e
+         (reset! caught true)
+         (is (= "test-exception" (:msg (ex-data e))))))
+      (is @caught "exception was not caught?"))
+    (let [caught (atom false)]
+      (try+
+       (throw+ {:msg "test-exception"})
+       (catch Object e
+         (reset! caught true)
+         (is (= "test-exception" (:msg e)))))
+      (is @caught "exception was not caught?"))))


### PR DESCRIPTION
in addition to trying to catch data, slingshot will now try to catch the wrapped exception as well.
this should be less confusing for new users and make migration to slingshot easier.

Signed-off-by: Sean Corfield <sean@corfield.org>